### PR TITLE
add <url> field in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
         <useBeta>true</useBeta>
     </properties>
     <name>Pipeline: Groovy HTTP</name>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
     <licenses>
         <license>
             <name>MIT License</name>


### PR DESCRIPTION
add the `<url>` field in pom.xml so that it points to GitHub
see https://jenkins.io/blog/2019/10/21/plugin-docs-on-github/#how-to-enable-github-documentation-for-your-plugin