### PR TITLE
Add base64Decode checkbox for Gerrit API

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ The HTTP Pipeline Plugin was implemented to retrieve Jenkinsfiles through HTTP (
 URL: https://api.github.com/repos/[your_org]/[your_repo]/contents/[path_in_repo]?ref=master
 Accept Header: application/vnd.github.VERSION.raw
 
+### Use with the Gerrit API
+
+[Gerrit API](https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#get-content)
+Using gerrit rest api you can fetch contents of the file, It is in base64 encoded format. This plugin supports decoding the content.
+
 ## Releasing
 To release simply call the following script:
 ```

--- a/src/main/java/org/jenkinsci/plugins/workflowhttp/cps/CpsHttpFlowDefinition.java
+++ b/src/main/java/org/jenkinsci/plugins/workflowhttp/cps/CpsHttpFlowDefinition.java
@@ -69,18 +69,20 @@ public class CpsHttpFlowDefinition extends FlowDefinition {
   private final String setKeyHeader;
   private final String setValueHeader;
   private final int retryCount;
+  private final boolean base64Decode;
   private final CachingConfiguration cachingConfiguration;
   private String credentialsId;
 
   @DataBoundConstructor
   public CpsHttpFlowDefinition(
-      String scriptUrl, String setAcceptHeader, String setKeyHeader, String setValueHeader,  int retryCount, CachingConfiguration cachingConfiguration) {
+      String scriptUrl, String setAcceptHeader, String setKeyHeader, String setValueHeader,  int retryCount, CachingConfiguration cachingConfiguration, boolean base64Decode) {
     this.scriptUrl = scriptUrl.trim();
     this.setAcceptHeader = setAcceptHeader;
     this.setKeyHeader = setKeyHeader;
     this.setValueHeader = setValueHeader;
     this.retryCount = retryCount;
     this.cachingConfiguration = cachingConfiguration;
+    this.base64Decode = base64Decode;
   }
 
   public String getScriptUrl() {
@@ -107,6 +109,10 @@ public class CpsHttpFlowDefinition extends FlowDefinition {
 
   public String getCredentialsId() {
     return credentialsId;
+  }
+
+  public boolean getBase64Decode() {
+    return base64Decode;
   }
 
   @DataBoundSetter
@@ -198,7 +204,7 @@ public class CpsHttpFlowDefinition extends FlowDefinition {
             "get pipeline from " + expandedScriptUrl,
             c -> c.execute(httpGet),
             response -> {
-              try (InputStream is = response.getEntity().getContent()) {
+              try (InputStream is = base64Decode ? Base64.getDecoder().wrap(response.getEntity().getContent()) : response.getEntity().getContent()) {
                 String script = IOUtils.toString(is, "UTF-8");
                 pipelineCache.put(expandedScriptUrl, new CacheEntry(getExpirationDate(), script));
               }
@@ -213,7 +219,7 @@ public class CpsHttpFlowDefinition extends FlowDefinition {
           "get pipeline from " + expandedScriptUrl,
           c -> c.execute(httpGet),
           response -> {
-            try (InputStream is = response.getEntity().getContent()) {
+            try (InputStream is = base64Decode ? Base64.getDecoder().wrap(response.getEntity().getContent()) : response.getEntity().getContent()) {
               String script = IOUtils.toString(is, "UTF-8");
               scriptReference.set(script);
             }

--- a/src/main/resources/org/jenkinsci/plugins/workflowhttp/cps/CpsHttpFlowDefinition/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflowhttp/cps/CpsHttpFlowDefinition/config.jelly
@@ -43,6 +43,9 @@ THE SOFTWARE.
     <f:entry field="credentialsId" title="${%Credentials}" description="Basic auth credentials">
         <c:select />
     </f:entry>
+    <f:entry field="base64Decode" title="base64 decode" description="Decodes base64 encoded response">
+        <f:checkbox />
+    </f:entry>
     <f:block>
         <a href="pipeline-syntax" target="_blank">${%Pipeline Syntax}</a>
     </f:block>

--- a/src/main/resources/org/jenkinsci/plugins/workflowhttp/cps/CpsHttpFlowDefinition/help-base64Decode.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflowhttp/cps/CpsHttpFlowDefinition/help-base64Decode.html
@@ -1,0 +1,3 @@
+<div>
+    If the response is base64-encoded, this helps in decoding the response from script URL
+</div>


### PR DESCRIPTION
Gerrit API gives content in bas64encoded format. This change gives extra option to user to decode the content.

I have added a checkbox option in the config.jelly that takes input from the user whether the response needed to be base64 decoded. In the "CpsHttpFlowDefinition.java" changed the function according to the input. Also written a testcase that tests this feature.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
