### PR TITLE
Add symbol and use data bound setter for optional fields

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflowhttp/cps/CpsHttpFlowDefinition.java
+++ b/src/main/java/org/jenkinsci/plugins/workflowhttp/cps/CpsHttpFlowDefinition.java
@@ -54,6 +54,7 @@ import jenkins.model.Jenkins;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpHeaders;
 import org.apache.http.client.methods.HttpGet;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowFactoryAction2;
 import org.jenkinsci.plugins.workflow.cps.persistence.PersistIn;
@@ -64,14 +65,14 @@ import org.kohsuke.stapler.*;
 public class CpsHttpFlowDefinition extends FlowDefinition {
 
     private final String scriptUrl;
-    private final String setAcceptHeader;
-    private final String setKeyHeader;
-    private final String setValueHeader;
-    private final int retryCount;
-    private final CachingConfiguration cachingConfiguration;
+    private String setAcceptHeader;
+    private String setKeyHeader;
+    private String setValueHeader;
+    private int retryCount;
+    private CachingConfiguration cachingConfiguration;
     private String credentialsId;
 
-    @DataBoundConstructor
+    @Deprecated
     public CpsHttpFlowDefinition(
             String scriptUrl,
             String setAcceptHeader,
@@ -85,6 +86,11 @@ public class CpsHttpFlowDefinition extends FlowDefinition {
         this.setValueHeader = setValueHeader;
         this.retryCount = retryCount;
         this.cachingConfiguration = cachingConfiguration;
+    }
+
+    @DataBoundConstructor
+    public CpsHttpFlowDefinition(String scriptUrl) {
+        this.scriptUrl = scriptUrl.trim();
     }
 
     public String getScriptUrl() {
@@ -117,6 +123,31 @@ public class CpsHttpFlowDefinition extends FlowDefinition {
 
     public String getCredentialsId() {
         return credentialsId;
+    }
+
+    @DataBoundSetter
+    public void setSetAcceptHeader(String setAcceptHeader) {
+        this.setAcceptHeader = setAcceptHeader;
+    }
+
+    @DataBoundSetter
+    public void setSetKeyHeader(String setKeyHeader) {
+        this.setKeyHeader = setKeyHeader;
+    }
+
+    @DataBoundSetter
+    public void setSetValueHeader(String setValueHeader) {
+        this.setValueHeader = setValueHeader;
+    }
+
+    @DataBoundSetter
+    public void setRetryCount(int retryCount) {
+        this.retryCount = retryCount;
+    }
+
+    @DataBoundSetter
+    public void setCachingConfiguration(CachingConfiguration cachingConfiguration) {
+        this.cachingConfiguration = cachingConfiguration;
     }
 
     @DataBoundSetter
@@ -232,6 +263,7 @@ public class CpsHttpFlowDefinition extends FlowDefinition {
     }
 
     @Extension
+    @Symbol("cpsHttp")
     public static class DescriptorImpl extends FlowDefinitionDescriptor {
         @Override
         @Nonnull

--- a/src/test/java/org/jenkinsci/plugins/workflowhttp/cps/CpsHttpFlowDefinitionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflowhttp/cps/CpsHttpFlowDefinitionTest.java
@@ -45,6 +45,22 @@ public class CpsHttpFlowDefinitionTest {
     public JenkinsRule r = new JenkinsRule();
 
     @Test
+    public void testRunScriptFromUserContentWithDefault() throws Exception {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        Path path =
+                Paths.get(r.jenkins.getRootPath().getRemote(), "userContent", "testRunScriptFromUserContent.groovy");
+        Files.write(path, "echo 'Hello from HTTP'".getBytes());
+
+        String url = r.jenkins.getRootUrl() + "userContent/testRunScriptFromUserContent.groovy";
+        CpsHttpFlowDefinition def = new CpsHttpFlowDefinition(url);
+        p.setDefinition(def);
+        WorkflowRun b = r.buildAndAssertSuccess(p);
+        r.assertLogContains("Fetching pipeline from " + url, b);
+        r.assertLogContains("No caching config. Fetching from HTTP", b);
+        r.assertLogContains("Hello from HTTP", b);
+    }
+
+    @Test
     public void testRunScriptFromUserContent() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         Path path =


### PR DESCRIPTION
Add symbol and use data bound setter for optional fields

Avoid

```
Caused by: javaposse.jobdsl.dsl.DslScriptException: (script, line 5) the following options are required and must be specified: setAcceptHeader, setKeyHeader, setValueHeader, retryCount, cachingConfiguration
```

Will allow to not force adding optional attribute and user friendly symbol

```groovy
pipelineJob('cps-http-test') {
  displayName('cps-http-test')
  description('cps-http-test')
  definition {
    cpsHttp {
       scriptUrl("https://.....")
    }
  }
}
```

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
